### PR TITLE
fix(ZILCH-50597): replace system metrics with kube-state-metrics denominators in resource capacity monitors

### DIFF
--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -11,7 +11,7 @@ module "cpu_limits_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available CPU for Limits in percentages Low"
-  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name} / max:system.cpu.num_cores{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
+  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster {{kube_cluster_name.name}} cpu room for limits / percentage is too low"
   recovery_message = "Kubernetes cluster {{kube_cluster_name.name}} cpu limits / percentage has recovered"
 

--- a/cpu-on-dns-pods-high.tf
+++ b/cpu-on-dns-pods-high.tf
@@ -13,7 +13,7 @@ module "cpu_on_dns_pods_high" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "CPU Usage on DNS pods is high"
-  query            = "avg(${var.cpu_on_dns_pods_high_evaluation_period}):avg:docker.cpu.usage{${local.cpu_on_dns_pods_high_filter}} by {kube_cluster_name,host,container_name} > ${var.cpu_on_dns_pods_high_critical}"
+  query            = "avg(${var.cpu_on_dns_pods_high_evaluation_period}):100 * avg:kubernetes.cpu.usage.total{${local.cpu_on_dns_pods_high_filter}} by {kube_cluster_name,pod_name,kube_container_name} / (avg:kubernetes_state.container.cpu_limit{${local.cpu_on_dns_pods_high_filter}} by {kube_cluster_name,pod_name,kube_container_name} * 1e9) > ${var.cpu_on_dns_pods_high_critical}"
   alert_message    = "Kubernetes CPU usage on DNS pods is too high"
   recovery_message = "Kubernetes CPU usage on DNS pods has recovered"
 

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -11,7 +11,7 @@ module "cpu_requests_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available CPU for requests in percentages Low"
-  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} / max:system.cpu.num_cores{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} > ${var.cpu_requests_low_perc_critical}"
+  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} > ${var.cpu_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster cpu room for requests / percentage is too low"
   recovery_message = "Kubernetes cluster cpu requests / percentage has recovered"
 

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -11,7 +11,7 @@ module "memory_limits_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available Memory for Limits in percentage Low"
-  query            = "max(${var.memory_limits_low_perc_evaluation_period}):( max:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}}  by {host,kube_cluster_name}/ max:system.mem.total{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
+  query            = "max(${var.memory_limits_low_perc_evaluation_period}):(sum:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for limits in percentage is too low"
   recovery_message = "Kubernetes cluster memory limits in percentage has recovered"
 

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -11,7 +11,7 @@ module "memory_requests_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available Memory for Requests in percentage Low"
-  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):( max:kubernetes.memory.requests{${local.cpu_requests_low_perc_filter}} / max:system.mem.total{${local.cpu_requests_low_perc_filter}} ) * 100 > ${var.cpu_requests_low_perc_critical}"
+  query            = "max(${var.memory_requests_low_perc_evaluation_period}):(sum:kubernetes.memory.requests{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for Requests in percentage is too low"
   recovery_message = "Kubernetes cluster memory Requests in percentage has recovered"
 

--- a/node-memory-used-percent.tf
+++ b/node-memory-used-percent.tf
@@ -11,7 +11,7 @@ module "node_memory_used_percent" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Memory Used Percent"
-  query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} ) / max:system.mem.total{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} > ${var.node_memory_used_percent_critical}"
+  query            = "avg(${var.node_memory_used_percent_evaluation_period}):( 100 * max:kubernetes.memory.usage{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} ) / sum:kubernetes_state.node.memory_allocatable{${local.node_memory_used_percent_filter}} by {host,kube_cluster_name} > ${var.node_memory_used_percent_critical}"
   alert_message    = "Available memory on ${var.service} Node {{host.name}} has dropped below {{threshold}} and has {{value}}% available"
   recovery_message = "Available memory on ${var.service} Node {{host.name}} has recovered {{value}}%"
 


### PR DESCRIPTION
## Summary

Fixes unreliable denominators in the four CPU/memory capacity monitors.

`system.cpu.num_cores` and `system.mem.total` report physical node capacity which:
- Does not account for OS/kube-system daemon reservations
- Behaves inconsistently on autoscaling nodes (node briefly reports wrong counts)
- Does not reflect what the Kubernetes scheduler actually sees as schedulable capacity

### Changes

| File | Old denominator | New denominator |
|---|---|---|
| `cpu-requests-low-perc.tf` | `max:system.cpu.num_cores` | `sum:kubernetes_state.node.cpu_capacity` |
| `cpu-limits-low-perc.tf` | `max:system.cpu.num_cores` | `sum:kubernetes_state.node.cpu_capacity` |
| `memory-requests-low-perc.tf` | `max:system.mem.total` | `sum:kubernetes_state.node.memory_allocatable` |
| `memory-limits-low-perc.tf` | `max:system.mem.total` | `sum:kubernetes_state.node.memory_allocatable` |

Also fixes a copy-paste bug in `memory-requests-low-perc.tf` that was referencing `cpu_requests_low_perc_*` variables throughout the query and was missing `by {host,kube_cluster_name}` grouping.

`memory_allocatable` is used (rather than `memory_capacity`) as it excludes memory reserved for OS and kube-system daemons, giving the true schedulable headroom.

## Jira

ZILCH-50597