### PR TITLE
fix: replace kube-state-metrics denominators and use avg/last_30m for…

### DIFF
--- a/cpu-limits-low-perc-variables.tf
+++ b/cpu-limits-low-perc-variables.tf
@@ -15,7 +15,7 @@ variable "cpu_limits_low_perc_critical" {
 
 variable "cpu_limits_low_perc_evaluation_period" {
   type    = string
-  default = "last_5m"
+  default = "last_30m"
 }
 
 variable "cpu_limits_low_perc_note" {

--- a/cpu-limits-low-perc.tf
+++ b/cpu-limits-low-perc.tf
@@ -11,7 +11,7 @@ module "cpu_limits_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available CPU for Limits in percentages Low"
-  query            = "max(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
+  query            = "avg(${var.cpu_limits_low_perc_evaluation_period}):(sum:kubernetes.cpu.limits{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.cpu_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster {{kube_cluster_name.name}} cpu room for limits / percentage is too low"
   recovery_message = "Kubernetes cluster {{kube_cluster_name.name}} cpu limits / percentage has recovered"
 

--- a/cpu-requests-low-perc-variables.tf
+++ b/cpu-requests-low-perc-variables.tf
@@ -15,7 +15,7 @@ variable "cpu_requests_low_perc_critical" {
 
 variable "cpu_requests_low_perc_evaluation_period" {
   type    = string
-  default = "last_5m"
+  default = "last_30m"
 }
 
 variable "cpu_requests_low_perc_note" {

--- a/cpu-requests-low-perc.tf
+++ b/cpu-requests-low-perc.tf
@@ -11,7 +11,7 @@ module "cpu_requests_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available CPU for requests in percentages Low"
-  query            = "max(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} > ${var.cpu_requests_low_perc_critical}"
+  query            = "avg(${var.cpu_requests_low_perc_evaluation_period}):100 * sum:kubernetes.cpu.requests{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} / sum:kubernetes_state.node.cpu_capacity{${local.cpu_requests_low_perc_filter}} by {kube_cluster_name,host} > ${var.cpu_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster cpu room for requests / percentage is too low"
   recovery_message = "Kubernetes cluster cpu requests / percentage has recovered"
 

--- a/memory-limits-low-perc-variables.tf
+++ b/memory-limits-low-perc-variables.tf
@@ -15,7 +15,7 @@ variable "memory_limits_low_perc_critical" {
 
 variable "memory_limits_low_perc_evaluation_period" {
   type    = string
-  default = "last_5m"
+  default = "last_30m"
 }
 
 variable "memory_limits_low_perc_note" {

--- a/memory-limits-low-perc.tf
+++ b/memory-limits-low-perc.tf
@@ -11,7 +11,7 @@ module "memory_limits_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available Memory for Limits in percentage Low"
-  query            = "max(${var.memory_limits_low_perc_evaluation_period}):(sum:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
+  query            = "avg(${var.memory_limits_low_perc_evaluation_period}):(sum:kubernetes.memory.limits{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_limits_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_limits_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for limits in percentage is too low"
   recovery_message = "Kubernetes cluster memory limits in percentage has recovered"
 

--- a/memory-requests-low-perc-variables.tf
+++ b/memory-requests-low-perc-variables.tf
@@ -15,7 +15,7 @@ variable "memory_requests_low_perc_critical" {
 
 variable "memory_requests_low_perc_evaluation_period" {
   type    = string
-  default = "last_5m"
+  default = "last_30m"
 }
 
 variable "memory_requests_low_perc_note" {

--- a/memory-requests-low-perc.tf
+++ b/memory-requests-low-perc.tf
@@ -11,7 +11,7 @@ module "memory_requests_low_perc" {
   source = "github.com/Zilch-Technology/terraform-datadog-generic-monitor"
 
   name             = "Available Memory for Requests in percentage Low"
-  query            = "max(${var.memory_requests_low_perc_evaluation_period}):(sum:kubernetes.memory.requests{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_requests_low_perc_critical}"
+  query            = "avg(${var.memory_requests_low_perc_evaluation_period}):(sum:kubernetes.memory.requests{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name} / sum:kubernetes_state.node.memory_allocatable{${local.memory_requests_low_perc_filter}} by {host,kube_cluster_name}) * 100 > ${var.memory_requests_low_perc_critical}"
   alert_message    = "Kubernetes cluster memory room for Requests in percentage is too low"
   recovery_message = "Kubernetes cluster memory Requests in percentage has recovered"
 


### PR DESCRIPTION
… cpu/memory request/limit monitors